### PR TITLE
Race condition during file write and parallel read. datenstrom/yellow#861

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -1,6 +1,6 @@
 <p align="right"><a href="README-de.md">Deutsch</a> &nbsp; <a href="README.md">English</a> &nbsp; <a href="README-sv.md">Svenska</a></p>
 
-# Core 0.8.108
+# Core 0.8.109
 
 Kernfunktionalität der Webseite.
 

--- a/README-sv.md
+++ b/README-sv.md
@@ -1,6 +1,6 @@
 <p align="right"><a href="README-de.md">Deutsch</a> &nbsp; <a href="README.md">English</a> &nbsp; <a href="README-sv.md">Svenska</a></p>
 
-# Core 0.8.108
+# Core 0.8.109
 
 Webbplatsens kärnfunktion.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="right"><a href="README-de.md">Deutsch</a> &nbsp; <a href="README.md">English</a> &nbsp; <a href="README-sv.md">Svenska</a></p>
 
-# Core 0.8.108
+# Core 0.8.109
 
 Core functionality of the website.
 

--- a/core.php
+++ b/core.php
@@ -2,7 +2,7 @@
 // Core extension, https://github.com/annaesvensson/yellow-core
 
 class YellowCore {
-    const VERSION = "0.8.108";
+    const VERSION = "0.8.109";
     const RELEASE = "0.8.22";
     public $content;        // content files
     public $media;          // media files
@@ -1974,8 +1974,11 @@ class YellowToolbox {
         $fileHandle = @fopen($fileName, "rb");
         if ($fileHandle) {
             clearstatcache(true, $fileName);
-            $fileSize = $sizeMax ? $sizeMax : filesize($fileName);
-            if ($fileSize) $fileData = fread($fileHandle, $fileSize);
+            if (flock($fileHandle, LOCK_SH)) {
+                $fileSize = $sizeMax ? $sizeMax : filesize($fileName);
+                if ($fileSize) $fileData = fread($fileHandle, $fileSize);
+                flock($fileHandle, LOCK_UN);
+            }
             fclose($fileHandle);
         }
         return $fileData;
@@ -1988,7 +1991,7 @@ class YellowToolbox {
             $path = dirname($fileName);
             if (!is_string_empty($path) && !is_dir($path)) @mkdir($path, 0777, true);
         }
-        $fileHandle = @fopen($fileName, "wb");
+        $fileHandle = @fopen($fileName, "cb");
         if ($fileHandle) {
             clearstatcache(true, $fileName);
             if (flock($fileHandle, LOCK_EX)) {

--- a/extension.ini
+++ b/extension.ini
@@ -1,11 +1,11 @@
 # Datenstrom Yellow extension settings
 
 Extension: Core
-Version: 0.8.108
+Version: 0.8.109
 Description: Core functionality of the website.
 DocumentationUrl: https://github.com/annaesvensson/yellow-core
 DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/main/downloads/core.zip
-Published: 2023-04-16 23:48:53
+Published: 2023-04-20 06:01:12
 Developer: Mark Seuffert, David Fehrmann
 Tag: feature
 system/extensions/core.php: core.php, create, update


### PR DESCRIPTION
Steps to reproduce:
* Replace `if ($this->yellow->system->get("updateEventDaily")<=time()) {` by `if (true) {` in `update.php` to allow `yellow-system.ini` rewrites on every webrequest
* Test website with browser
* Run webserver with multiple threads for web requests (`PHP_CLI_SERVER_WORKERS=10 php -e -S 127.0.0.1:8000 yellow.php 2> out.txt`)
* Start concurrent webrequests (`ab -n 100000 -c 10 http://127.0.0.1:8000/`)
* Test website with browser during or after the test

Current result:
* Website is broken after a few seconds (in my case)

Expected:
* Website should still work

Problems found:
* When `createFile` is running on one thread an `readFile` on another the `readFile` returns an empty string
* The `createFile` function truncates the file during opening before a lock could be set
* The `readFile` didn't acquire a lock to wait for the write after truncation

Fix:
* Changed the `fopen()` in `createFile` to "open for write but don't truncate" -> "cb"
* The file is already truncated again after the lock is set
* Added a shared read lock in `readFile` to wait for `createFile` if active


Please test and verify on your machine. :)
