### PR TITLE
Fixed getDateRelative() to use midnight as reference point

### DIFF
--- a/core.php
+++ b/core.php
@@ -2,7 +2,7 @@
 // Core extension, https://github.com/annaesvensson/yellow-core
 
 class YellowCore {
-    const VERSION = "0.8.125";
+    const VERSION = "0.8.126";
     const RELEASE = "0.8.23";
     public $content;        // content files
     public $media;          // media files
@@ -876,7 +876,7 @@ class YellowLanguage {
     
     // Return Unix time as date, relative to today
     public function getDateRelative($timestamp, $format, $daysLimit, $language = "") {
-        $timeDifference = time() - $timestamp;
+        $timeDifference = mktime(0, 0, 0) - strtotime(date("Y-m-d", $timestamp));
         $days = abs(intval($timeDifference/86400));
         $key = $timeDifference>=0 ? "coreDatePast" : "coreDateFuture";
         $tokens = preg_split("/\s*,\s*/", $this->getText($key, $language));


### PR DESCRIPTION
… be labelled as today's page.

The bug in the function getDateRelative() results in a page created at 18:00 being output at 13:00 on the following day today as relative date, which is wrong.

I have modified getDateRelative() with the help of Mark so that the basis for calculating the time difference is the date and not the time (86400s (24h)) so now the date of the publication is checked against today's date and outputs the correct relative date.